### PR TITLE
Hid two unused servers

### DIFF
--- a/about/record.html
+++ b/about/record.html
@@ -12,6 +12,7 @@ title: About
 			<div id="about_records" class="animated fadeIn">
 				<p id="about_section_header">&nbsp; Scrim Records &nbsp;</p>
 				<p id="about_section_text"><b>Opponents &nbsp; Date of engagement &nbsp; Outcome</b></p>
+				<p id="about_section_text">&#9675; <a href="https://forums.29th.org/discussion/37465" target="_blank">EP3 vs Canadian Forces</a>&nbsp;&nbsp;&nbsp;April 25th 2020&nbsp;&nbsp;&nbsp;<span class="green">Victory</span></p>
 				<p id="about_section_text">&#9675; <a href="http://forums.29th.org/discussion/35268/ep2-vs-7th-cavalry-and-3rd-ranger-battalion-official-scrimmage-write-up-and-awards#latest" target="_blank">EP2 vs 7th Cavalry and 3rd Rangers</a>&nbsp;&nbsp;&nbsp;December 7th 2019&nbsp;&nbsp;&nbsp;<span class="green">Victory</span></p>
 				<p id="about_section_text">&#9675; <a href="http://forums.29th.org/categories/promotions-and-awards" target="_blank">DBoTs I</a>&nbsp;&nbsp;&nbsp;December 5th 2019&nbsp;&nbsp;&nbsp;<span class="green">DP2S2 Victory</span></p>
 				<p id="about_section_text">&#9675; <a href="http://forums.29th.org/discussion/35060" target="_blank">EP1 vs 508th PIR & 3rd Rangers</a>&nbsp;&nbsp;&nbsp;November 9th 2019&nbsp;&nbsp;&nbsp;<span class="green">Victory</span></p>
@@ -21,7 +22,7 @@ title: About
 				<p id="about_section_text">&#9675; <a href="http://forums.29th.org/discussion/28651" target="_blank">DP2 vs DMC</a>&nbsp;&nbsp;&nbsp;August 12th 2018&nbsp;&nbsp;&nbsp;<span class="green">Victory</span></p>
 				<br>
 				<p id="about_section_text">&#9675; <a href="http://forums.29th.org/discussion/21955" target="_blank">CP2 vs 2MRB</a>&nbsp;&nbsp;&nbsp;November 4th and 11th 2017	&nbsp;&nbsp;&nbsp;<span class="green">Victory</span></p>
-				<p id="about_section_text">&#9675; <a href="http://forums.29th.org/discussion/18259" target="_blank">AP3 vs. 352nd</a>&nbsp;&nbsp;&nbsp;April 29th 2017&nbsp;&nbsp;&nbsp;<span class="green">Victory</span></p>
+				<p id="about_section_text">&#9675; <a href="http://forums.29th.org/discussion/18259" target="_blank">AP3 vs 352nd</a>&nbsp;&nbsp;&nbsp;April 29th 2017&nbsp;&nbsp;&nbsp;<span class="green">Victory</span></p>
 				<p id="about_section_text">&#9675; <a href="http://forums.29th.org/discussion/18144" target="_blank">BP1 vs 1st SS</a>&nbsp;&nbsp;&nbsp;April 23rd 2017&nbsp;&nbsp;&nbsp;<span class="green">Victory</span></p>
 				<br>
 				<p id="about_section_text">&#9675; <a href="http://forums.29th.org/discussion/15439" target="_blank">AP4 vs 352nd</a>&nbsp;&nbsp;&nbsp;October 15th 2016&nbsp;&nbsp;&nbsp;<span class="green">Victory</span></p>

--- a/servers.html
+++ b/servers.html
@@ -70,7 +70,6 @@ title: Servers
 				<center>
 					<img style="padding-bottom: 1vh;" src="https://cdn.battlemetrics.com/b/standardVertical/2673884.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 					<img style="padding-bottom: 1vh;" src="https://cdn.battlemetrics.com/b/standardVertical/1167640.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
-					<img style="padding-bottom: 1vh;" src="https://cdn.battlemetrics.com/b/standardVertical/5268260.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 					<img style="padding-bottom: 1vh;" src="https://cdn.battlemetrics.com/b/standardVertical/1478165.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 					<img src="https://cdn.battlemetrics.com/b/standardVertical/1478164.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 				</center>
@@ -80,12 +79,10 @@ title: Servers
 			</div>
 			<div id="battlemetrics_small">
 				<center>
-					<img style="padding-bottom: 1vh; display: none;" src="https://cdn.battlemetrics.com/b/standardVertical/4856675.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 					<img style="padding-bottom: 1vh;" src="https://cdn.battlemetrics.com/b/standardVertical/4935697.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 					<img style="padding-bottom: 1vh;" src="https://cdn.battlemetrics.com/b/standardVertical/5085148.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 					<img style="padding-bottom: 1vh;" src="https://cdn.battlemetrics.com/b/standardVertical/5085150.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 					<img style="padding-bottom: 1vh;" src="https://cdn.battlemetrics.com/b/standardVertical/1478167.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
-					<img style="padding-bottom: 1vh; display: none;" src="https://cdn.battlemetrics.com/b/standardVertical/5397212.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 				</center>
 			</div>
 		</div>

--- a/servers.html
+++ b/servers.html
@@ -80,12 +80,12 @@ title: Servers
 			</div>
 			<div id="battlemetrics_small">
 				<center>
-					<img style="padding-bottom: 1vh;" src="https://cdn.battlemetrics.com/b/standardVertical/4856675.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
+					<img style="padding-bottom: 1vh; display: none;" src="https://cdn.battlemetrics.com/b/standardVertical/4856675.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 					<img style="padding-bottom: 1vh;" src="https://cdn.battlemetrics.com/b/standardVertical/4935697.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 					<img style="padding-bottom: 1vh;" src="https://cdn.battlemetrics.com/b/standardVertical/5085148.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 					<img style="padding-bottom: 1vh;" src="https://cdn.battlemetrics.com/b/standardVertical/5085150.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 					<img style="padding-bottom: 1vh;" src="https://cdn.battlemetrics.com/b/standardVertical/1478167.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
-					<img src="https://cdn.battlemetrics.com/b/standardVertical/5397212.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
+					<img style="padding-bottom: 1vh; display: none;" src="https://cdn.battlemetrics.com/b/standardVertical/5397212.png?foreground=%23EEEEEE&linkColor=%231185ec&lines=%23333333&background=%23222222&chart=players%3A24H&chartColor=%23FF0700&maxPlayersHeight=300" />
 				</center>
 			</div>
 		</div>


### PR DESCRIPTION
Two of the Squad Server's Battlemetrics are now unused so I gave them the `display: none;` inline CSS tag to hide them until they are needed in the future.